### PR TITLE
Implement login-form and client-side session control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ typings/
 
 # compiled code
 dist/
+
+# IDE
+.idea

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "history": "^4.7.2",
     "html-loader": "^0.5.5",
     "html-webpack-plugin": "^3.2.0",
+    "jsonwebtoken": "^8.3.0",
     "locutus": "^2.0.9",
     "md5": "^2.2.1",
     "npm": "^6.1.0",

--- a/src/actions/userActions.js
+++ b/src/actions/userActions.js
@@ -5,14 +5,16 @@ import {
 } from "../constants/userActionTypes"
 import { userListFetch } from "../actions/userListActions"
 
-export const userLogin = (username, md5password) => (dispatch, getState, client) => {
+export const userLogin = (username, password) => (dispatch, getState, client) => {
     // We want to handle an Async action, dispatch a "Loading" action.
     dispatch(userLoginPending())
 
-    client.login(username, md5password).then(response => {
+    client.login(username, password).then(response => {
         // When API call is successful.
         // Set authorization header in API HTTP middleware.
         client.setAuthorizationToken(response.token);
+
+        // TODO: Save token on client
 
         // Dispatch a fulfilled action.
         dispatch(userLoginFulfilled(response))
@@ -39,30 +41,19 @@ const userLoginRejected = data => ({
 })
 
 export const userLogout = () => (dispatch, getState, client) => {
-    // We want to handle an Async action, dispatch a "Loading" action.
     dispatch(userLogoutPending())
 
-    client.logout().then(response => {
-        // When API call is successful, dispatch a fulfilled action.
-        dispatch(userLogoutFulfilled(response))
-    }).catch(response => {
-        // When an error (network or applicative) occurs, dispatch a rejected action.
-        dispatch(userLogoutRejected(response))
-    })
+    // TODO: Remove session on client or server
+
+    dispatch(userLogoutFulfilled())
 }
 
 const userLogoutPending = () => ({
     type: USER_LOGOUT_PENDING
 })
 
-const userLogoutFulfilled = data => ({
-    type: USER_LOGOUT_FULFILLED,
-    payload: data
-})
-
-const userLogoutRejected = data => ({
-    type: USER_LOGOUT_REJECTED,
-    payload: data
+const userLogoutFulfilled = () => ({
+    type: USER_LOGOUT_FULFILLED
 })
 
 export const userDelete = userId => (dispatch, getState, client) => {

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -1,13 +1,15 @@
 import React, { Component } from 'react'
 import { connect } from "react-redux"
 import { Route, Switch, Link } from 'react-router-dom'
+import { ConnectedRouter } from 'react-router-redux'
+
 import NodeList from './NodeList'
 import RoleList from './RoleList'
 import UserList from './UserList'
-import { ConnectedRouter } from 'react-router-redux'
+import CurrentUserInfo from './CurrentUserInfo'
+import LoginForm from '../forms/loginForm'
 import { history } from '../stores/store'
 import './App.css'
-import { userLogin } from '../actions/userActions'
 
 // Jihye: add User Register
 import UserRegister from './UserRegister'
@@ -18,25 +20,22 @@ class App extends Component {
     }
 
     render() {
-        if (this.props.currentUser === false && this.props.loading === false && this.props.error === false) {
-            // If there user is not authentified yet. Authenticate him.
-            // TODO: move params as env variable? When we know where they are suppose to come from...
-            this.props.authenticate('Remi', 'password')
-            return <div></div>
+        const { currentUser, loading } = this.props;
 
-        } else if (this.props.currentUser === false && this.props.loading === true) {
+        if (currentUser === false && loading === false) {
+            // If there user is not authenticated, show LoginForm (whether error or not)
+            return <LoginForm />
+
+        } else if (currentUser === false && loading === true) {
             // If authentication request is pending, return nothing.
-            return <div></div>
-
-        } else if (this.props.error !== false) {
-            // If authentication request failed.
-            return <div><p>Authentication error: {this.props.error}.</p></div>
+            return <div>Loading..</div>
 
         } else {
             return (
                     <div>
                         <h1>React/Redux User Interface</h1>
-                       
+                        <CurrentUserInfo />
+
                         <ConnectedRouter history={history}>
                         <Switch>
                             <Route exact path="/" component={NodeList} />
@@ -55,14 +54,14 @@ class App extends Component {
 const mapStateToProps = state => ({
     loading: state.user.authentication.loading,
     currentUser: state.user.authentication.currentUser,
-    token: state.user.authentication.token,
-    error: state.user.authentication.error
+    //token: state.user.authentication.token,
+    //error: state.user.authentication.error
 })
 
 const mapDispatchToProps = dispatch => ({
-    authenticate: (username, md5password) => {
-        dispatch(userLogin(username, md5password))
-    }
+    // authenticate: (username, md5password) => {
+    //     dispatch(userLogin(username, md5password))
+    // }
 })
 
 export default connect(mapStateToProps, mapDispatchToProps) (App)

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -8,6 +8,7 @@ import RoleList from './RoleList'
 import UserList from './UserList'
 import CurrentUserInfo from './CurrentUserInfo'
 import LoginForm from '../forms/loginForm'
+import * as userActions from "../actions/userActions";
 import { history } from '../stores/store'
 import './App.css'
 
@@ -17,6 +18,10 @@ import UserRegister from './UserRegister'
 class App extends Component {
     constructor(props) {
         super(props)
+    }
+
+    componentWillMount() {
+        this.props.loadUserFromLocal();
     }
 
     render() {
@@ -59,9 +64,13 @@ const mapStateToProps = state => ({
 })
 
 const mapDispatchToProps = dispatch => ({
-    // authenticate: (username, md5password) => {
-    //     dispatch(userLogin(username, md5password))
-    // }
+    loadUserFromLocal: () => {
+        let token = sessionStorage.getItem('jwtToken');
+        if (!token || token === '')
+            return;
+
+        dispatch(userActions.meFromToken(token));
+    },
 })
 
 export default connect(mapStateToProps, mapDispatchToProps) (App)

--- a/src/containers/CurrentUserInfo.js
+++ b/src/containers/CurrentUserInfo.js
@@ -1,0 +1,36 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import * as userActions from '../actions/userActions'
+
+class CurrentUserInfo extends Component {
+    constructor(props) {
+        super(props);
+        this.handleLogout = this.handleLogout.bind(this);
+    }
+
+    handleLogout() {
+        this.props.logout();
+    }
+
+    render() {
+        const { currentUser } = this.props;
+        return (
+            <div>
+                <span>Hi {currentUser.name}</span><br />
+                <button onClick={this.handleLogout}>Logout</button>
+            </div>
+        )
+    }
+}
+
+const mapStateToProps = state => ({
+    currentUser: state.user.authentication.currentUser
+})
+
+const mapDispatchToProps = dispatch => ({
+    logout: () => {
+        dispatch(userActions.userLogout())
+    }
+})
+
+export default connect(mapStateToProps, mapDispatchToProps)(CurrentUserInfo)

--- a/src/forms/loginForm.css
+++ b/src/forms/loginForm.css
@@ -1,0 +1,30 @@
+.login-box{
+    font: 14px AppleGothic, sans-serif;
+    width: 400px;
+    margin: 50px auto;
+}
+
+.login-box h2{
+    font-size: 40px;
+    margin: 10px 0 10px;
+}
+
+.login-box input{
+    width: 200px;
+    margin: 3px 0;
+    padding: 5px 10px;
+    border: 1px solid #ddd;
+    outline: none;
+    font-size: 14px;
+}
+
+.login-box button{
+    margin: 10px 0;
+    padding: 6px 10px;
+    background-color: black;
+    border-radius: 0;
+    border: none;
+    outline: none;
+    font-size: 14px;
+    color: white;
+}

--- a/src/forms/loginForm.js
+++ b/src/forms/loginForm.js
@@ -1,0 +1,45 @@
+import React from 'react'
+import * as userActions from "../actions/userActions";
+import { Field, reduxForm } from 'redux-form'
+import { connect } from "react-redux";
+import './loginForm.css'
+
+class LoginForm extends React.Component {
+    constructor(props) {
+        super(props);
+        this.handleFormSubmit = this.handleFormSubmit.bind(this);
+    }
+
+    handleFormSubmit(formValues) {
+        this.props.login(formValues.username, formValues.password);
+    }
+
+    render() {
+        const { errMessage, handleSubmit } = this.props;
+        return (
+            <div className="login-box">
+                <h2>Login</h2>
+                <div style={{'color': 'red'}}>{errMessage}</div>
+                <form onSubmit={handleSubmit(this.handleFormSubmit)}>
+                    <Field name="username" component="input" type="text" /><br />
+                    <Field name="password" component="input" type="password" /><br />
+                    <button type="submit">Submit</button>
+                </form>
+            </div>
+        )
+    }
+}
+
+const mapStateToProps = (state) => ({
+    errMessage: state.user.authentication.error
+});
+
+const mapDispatchToProps = (dispatch) => ({
+    login: (username, password) => {
+        dispatch(userActions.userLogin(username, password))
+    }
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(
+    reduxForm({form: 'loginForm'})(LoginForm)
+)

--- a/src/reducers/user.js
+++ b/src/reducers/user.js
@@ -44,7 +44,7 @@ export const userReducer = (state = initialState, action) => {
             return {...state, ...{ authentication: {...state.authentication, ...{ loading: true, currentUser: false, error: false }} }};
             break;
         case USER_LOGOUT_FULFILLED:
-            return {...state, ...{ authentication: {...state.authentication, ...{ loading: false, currentUser: action.payload, error: false }} }};
+            return {...state, ...{ authentication: {...state.authentication, ...{ loading: false, currentUser: false, token: false, error: false }} }};
             break;
         case USER_LOGOUT_REJECTED:
             return {...state, ...{ authentication: {...state.authentication, ...{ loading: false, currentUser: false, error: action.payload }} }};


### PR DESCRIPTION
Remove below code, and show **login form** to enable login.

```js
 if (this.props.currentUser === false && this.props.loading === false && this.props.error === false) {
        // If there user is not authentified yet. Authenticate him.
        // TODO: move params as env variable? When we know where they are suppose to come from...
        this.props.authenticate('Remi', 'password')
        return <div></div>
```

Form is implemented in `<LoginForm />`, by using redux-form.

Since `actions` and `reducers` for *login* is already implemented, I used it since it is possible.

----

Currently **guest login** is not implemented.

Only logged-in users can use service because changing of permission code of back-end is also needed.

----

**Client-side session control** is implemented with `sessionStorage`.

If there is `jwtToken` in local, uses it's data.

If token is invalid, server would response error message.

If there is no token in local, user might attempt login, and then new token is saved to local.


![2018-07-17 12 19 32](https://user-images.githubusercontent.com/3872573/42840425-aee637ae-89bb-11e8-84eb-d60db622f5e9.png)
